### PR TITLE
Fix error in Get-AllNetworks

### DIFF
--- a/Functions/Wifi-Info.md
+++ b/Functions/Wifi-Info.md
@@ -83,9 +83,9 @@ Foreach($WLANProfileName in $WLANProfileNames){
     $WLANProfileObject | Add-Member -Type NoteProperty -Name "ProfileName" -Value $WLANProfileName
     $WLANProfileObject | Add-Member -Type NoteProperty -Name "ProfilePassword" -Value $WLANProfilePassword
     $WLANProfileObjects += $WLANProfileObject
-    Remove-Variable WLANProfileObject
-    return $WLANProfileObjects
+    Remove-Variable WLANProfileObject    
 }
+return $WLANProfileObjects
 }
 
 $Networks = Get-Networks


### PR DESCRIPTION
The "return $WLANProfileObjects" was within the wrong scope, and thus only returning the first result.