### PR TITLE
Fix exception thrown by, and suppress output from, the Speak function

### DIFF
--- a/Functions/Speak.md
+++ b/Functions/Speak.md
@@ -45,8 +45,8 @@ param (
 [string]$Sentence
 ) 
 
-$s.Voice = $s.GetVoices().Item(0)
 $s=New-Object -ComObject SAPI.SpVoice
+$s.Voice = $s.GetVoices().Item(0)
 $s.Rate = -2
 $s.Speak($Sentence)
 }

--- a/Functions/Speak.md
+++ b/Functions/Speak.md
@@ -48,7 +48,7 @@ param (
 $s=New-Object -ComObject SAPI.SpVoice
 $s.Voice = $s.GetVoices().Item(0)
 $s.Rate = -2
-$s.Speak($Sentence)
+$null = $s.Speak($Sentence)
 }
 ```
 


### PR DESCRIPTION
This PR stops the Speak function from throwing an exception when it tries to enumerate voices on the `SAPI.SpVoice` object before it has been created.

![image](https://user-images.githubusercontent.com/6955786/233548891-e1cd6c06-e6dc-4732-9c32-fc1adc088196.png)

Further, the `.Speak` method used in this function outputs a number that's used in apps to associate queued async streams with events. As a user though... it means nothing and as the function doesn't set the async flag, it always returns `1` anyway.

![image](https://user-images.githubusercontent.com/6955786/233549134-211be9fe-492a-4f22-88ad-5492c122f569.png)